### PR TITLE
Load antibody plugins dynamically

### DIFF
--- a/dot_config/zsh/dot_zshrc
+++ b/dot_config/zsh/dot_zshrc
@@ -1,2 +1,2 @@
 # Load zsh plugins
-source $XDG_CACHE_HOME/zsh/plugins.sh
+source <(antibody bundle < ~/.zsh-plugins)

--- a/run_05_install_zsh_plugins.sh
+++ b/run_05_install_zsh_plugins.sh
@@ -1,7 +1,0 @@
-#!/bin/sh
-. ./.profile
-set -eu
-
-# Use antibody static loading
-antibody bundle < ~/.zsh-plugins > $XDG_CACHE_HOME/zsh/plugins.sh
-


### PR DESCRIPTION
This avoids caching the hardcoded absolute plugin paths (with the user's home directory).
