### PR TITLE
Pin Ubuntu 24.04 and simplify Symphony mise setup

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM mcr.microsoft.com/devcontainers/base:ubuntu
+FROM mcr.microsoft.com/devcontainers/base:ubuntu-24.04
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     pkg-config \

--- a/home/.chezmoiscripts/run_onchange_after_30_symphony_setup.sh.tmpl
+++ b/home/.chezmoiscripts/run_onchange_after_30_symphony_setup.sh.tmpl
@@ -1,7 +1,14 @@
-#!/usr/bin/env -S mise exec erlang@28 -- /bin/sh -e -u
+#!/bin/sh
+set -eu
+
 # symphony HEAD: {{ output "git" "-C" (print .chezmoi.homeDir "/.local/share/symphony") "rev-parse" "HEAD" }}
 
-cd "$XDG_DATA_HOME/symphony/elixir"
+MISE_ERLANG_COMPILE=false mise install erlang@28
+erlang_bin="$(mise where erlang@28)/bin"
 
-mise exec elixir@1.19.5-otp-28 -- mix setup
-mise exec elixir@1.19.5-otp-28 -- mix build
+PATH="$erlang_bin:$PATH" mise install elixir@1.19.5-otp-28
+PATH="$erlang_bin:$PATH" MISE_ERLANG_COMPILE=false mise exec erlang@28 elixir@1.19.5-otp-28 -- sh -eu -c '
+cd "$XDG_DATA_HOME/symphony/elixir"
+mix setup
+mix build
+'

--- a/home/.chezmoiscripts/run_onchange_after_30_symphony_setup.sh.tmpl
+++ b/home/.chezmoiscripts/run_onchange_after_30_symphony_setup.sh.tmpl
@@ -3,7 +3,7 @@ set -eu
 
 # symphony HEAD: {{ output "git" "-C" (print .chezmoi.homeDir "/.local/share/symphony") "rev-parse" "HEAD" }}
 
-symphony_dir="${XDG_DATA_HOME:-$HOME/.local/share}/symphony/elixir"
+symphony_dir="$XDG_DATA_HOME/symphony/elixir"
 
 mise install erlang@28
 export PATH="$(mise where erlang@28)/bin:$PATH"

--- a/home/.chezmoiscripts/run_onchange_after_30_symphony_setup.sh.tmpl
+++ b/home/.chezmoiscripts/run_onchange_after_30_symphony_setup.sh.tmpl
@@ -3,14 +3,12 @@ set -eu
 
 # symphony HEAD: {{ output "git" "-C" (print .chezmoi.homeDir "/.local/share/symphony") "rev-parse" "HEAD" }}
 
-symphony_dir="$XDG_DATA_HOME/symphony/elixir"
-
 mise install erlang@28
 export PATH="$(mise where erlang@28)/bin:$PATH"
 
 mise install elixir@1.19.5-otp-28
 export PATH="$(mise where elixir@1.19.5-otp-28)/bin:$PATH"
 
-cd "$symphony_dir"
+cd "$XDG_DATA_HOME/symphony/elixir"
 mix setup
 mix build

--- a/home/.chezmoiscripts/run_onchange_after_30_symphony_setup.sh.tmpl
+++ b/home/.chezmoiscripts/run_onchange_after_30_symphony_setup.sh.tmpl
@@ -6,12 +6,10 @@ set -eu
 symphony_dir="${XDG_DATA_HOME:-$HOME/.local/share}/symphony/elixir"
 
 mise install erlang@28
-PATH="$(mise where erlang@28)/bin:$PATH"
-export PATH
+export PATH="$(mise where erlang@28)/bin:$PATH"
 
 mise install elixir@1.19.5-otp-28
-PATH="$(mise where elixir@1.19.5-otp-28)/bin:$PATH"
-export PATH
+export PATH="$(mise where elixir@1.19.5-otp-28)/bin:$PATH"
 
 cd "$symphony_dir"
 mix setup

--- a/home/.chezmoiscripts/run_onchange_after_30_symphony_setup.sh.tmpl
+++ b/home/.chezmoiscripts/run_onchange_after_30_symphony_setup.sh.tmpl
@@ -3,12 +3,8 @@ set -eu
 
 # symphony HEAD: {{ output "git" "-C" (print .chezmoi.homeDir "/.local/share/symphony") "rev-parse" "HEAD" }}
 
-mise install erlang@28
-export PATH="$(mise where erlang@28)/bin:$PATH"
-
-mise install elixir@1.19.5-otp-28
-export PATH="$(mise where elixir@1.19.5-otp-28)/bin:$PATH"
-
-cd "$XDG_DATA_HOME/symphony/elixir"
-mix setup
-mix build
+cd "$HOME/.local/share/symphony/elixir"
+mise trust
+mise install
+mise exec -- mix setup
+mise exec -- mix build

--- a/home/.chezmoiscripts/run_onchange_after_30_symphony_setup.sh.tmpl
+++ b/home/.chezmoiscripts/run_onchange_after_30_symphony_setup.sh.tmpl
@@ -3,12 +3,16 @@ set -eu
 
 # symphony HEAD: {{ output "git" "-C" (print .chezmoi.homeDir "/.local/share/symphony") "rev-parse" "HEAD" }}
 
-mise install erlang@28
-erlang_bin="$(mise where erlang@28)/bin"
+symphony_dir="${XDG_DATA_HOME:-$HOME/.local/share}/symphony/elixir"
 
-PATH="$erlang_bin:$PATH" mise install elixir@1.19.5-otp-28
-PATH="$erlang_bin:$PATH" mise exec erlang@28 elixir@1.19.5-otp-28 -- sh -eu -c '
-cd "$XDG_DATA_HOME/symphony/elixir"
+mise install erlang@28
+PATH="$(mise where erlang@28)/bin:$PATH"
+export PATH
+
+mise install elixir@1.19.5-otp-28
+PATH="$(mise where elixir@1.19.5-otp-28)/bin:$PATH"
+export PATH
+
+cd "$symphony_dir"
 mix setup
 mix build
-'

--- a/home/.chezmoiscripts/run_onchange_after_30_symphony_setup.sh.tmpl
+++ b/home/.chezmoiscripts/run_onchange_after_30_symphony_setup.sh.tmpl
@@ -3,11 +3,11 @@ set -eu
 
 # symphony HEAD: {{ output "git" "-C" (print .chezmoi.homeDir "/.local/share/symphony") "rev-parse" "HEAD" }}
 
-MISE_ERLANG_COMPILE=false mise install erlang@28
+mise install erlang@28
 erlang_bin="$(mise where erlang@28)/bin"
 
 PATH="$erlang_bin:$PATH" mise install elixir@1.19.5-otp-28
-PATH="$erlang_bin:$PATH" MISE_ERLANG_COMPILE=false mise exec erlang@28 elixir@1.19.5-otp-28 -- sh -eu -c '
+PATH="$erlang_bin:$PATH" mise exec erlang@28 elixir@1.19.5-otp-28 -- sh -eu -c '
 cd "$XDG_DATA_HOME/symphony/elixir"
 mix setup
 mix build

--- a/home/dot_local/bin/executable_symphony
+++ b/home/dot_local/bin/executable_symphony
@@ -1,3 +1,6 @@
-#!/usr/bin/env -S mise exec erlang@28 -- /bin/sh -e -u
+#!/bin/sh
+set -eu
 
+exec env MISE_ERLANG_COMPILE=false mise exec erlang@28 -- sh -eu -c '
 exec "$XDG_DATA_HOME/symphony/elixir/bin/symphony" "$@"
+' sh "$@"

--- a/home/dot_local/bin/executable_symphony
+++ b/home/dot_local/bin/executable_symphony
@@ -1,6 +1,6 @@
 #!/bin/sh
 set -eu
 
-exec mise exec erlang@28 -- sh -eu -c '
-exec "$XDG_DATA_HOME/symphony/elixir/bin/symphony" "$@"
-' sh "$@"
+symphony_bin="${XDG_DATA_HOME:-$HOME/.local/share}/symphony/elixir/bin/symphony"
+
+exec mise exec erlang@28 -- "$symphony_bin" "$@"

--- a/home/dot_local/bin/executable_symphony
+++ b/home/dot_local/bin/executable_symphony
@@ -1,3 +1,3 @@
 #!/usr/bin/env -S mise exec erlang@28 -- /bin/sh -eu
 
-exec "${XDG_DATA_HOME:-$HOME/.local/share}/symphony/elixir/bin/symphony" "$@"
+exec "$XDG_DATA_HOME/symphony/elixir/bin/symphony" "$@"

--- a/home/dot_local/bin/executable_symphony
+++ b/home/dot_local/bin/executable_symphony
@@ -1,6 +1,3 @@
-#!/bin/sh
-set -eu
+#!/usr/bin/env -S mise exec erlang@28 -- /bin/sh -eu
 
-symphony_bin="${XDG_DATA_HOME:-$HOME/.local/share}/symphony/elixir/bin/symphony"
-
-exec mise exec erlang@28 -- "$symphony_bin" "$@"
+exec "${XDG_DATA_HOME:-$HOME/.local/share}/symphony/elixir/bin/symphony" "$@"

--- a/home/dot_local/bin/executable_symphony
+++ b/home/dot_local/bin/executable_symphony
@@ -1,6 +1,6 @@
 #!/bin/sh
 set -eu
 
-exec env MISE_ERLANG_COMPILE=false mise exec erlang@28 -- sh -eu -c '
+exec mise exec erlang@28 -- sh -eu -c '
 exec "$XDG_DATA_HOME/symphony/elixir/bin/symphony" "$@"
 ' sh "$@"

--- a/home/dot_local/bin/executable_symphony
+++ b/home/dot_local/bin/executable_symphony
@@ -1,3 +1,4 @@
-#!/usr/bin/env -S mise exec erlang@28 -- /bin/sh -eu
+#!/usr/bin/env -S mise exec erlang@28 -- /bin/sh
+set -eu
 
 exec "$XDG_DATA_HOME/symphony/elixir/bin/symphony" "$@"


### PR DESCRIPTION
## Summary
- Pin the devcontainer base image to `ubuntu-24.04` so mise can use precompiled Erlang binaries during arm64 Docker builds.
- Simplify the Symphony setup script to trust the repo’s own `mise.toml`, install from it, and run `mix setup`/`mix build` through `mise exec`.
- Normalize the Symphony wrapper script to a consistent `set -eu` shell style.

## Testing
- Verified the arm64 Docker build completes successfully with the updated setup.
- Confirmed Symphony installs Erlang and Elixir from its repo config and generates the `bin/symphony` escript during setup.