### PR TITLE
[codex] Build arm Docker image natively

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -10,10 +10,8 @@ jobs:
         include:
           - platform: linux/amd64
             runner: ubuntu-latest
-            cache_scope: linux-amd64
           - platform: linux/arm64
             runner: ubuntu-24.04-arm
-            cache_scope: linux-arm64
     steps:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
@@ -39,8 +37,8 @@ jobs:
         uses: docker/build-push-action@v7
         with:
           file: .devcontainer/Dockerfile
-          cache-from: type=gha,scope=${{ matrix.cache_scope }}
-          cache-to: type=gha,mode=max,scope=${{ matrix.cache_scope }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
           platforms: ${{ matrix.platform }}
           push: ${{ github.ref_name == 'main' }}
           tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,14 +4,17 @@ on: push
 
 jobs:
   docker:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runner }}
     strategy:
       matrix:
-        platform: [linux/amd64, linux/arm64]
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+            cache_scope: linux-amd64
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+            cache_scope: linux-arm64
     steps:
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
@@ -36,8 +39,8 @@ jobs:
         uses: docker/build-push-action@v7
         with:
           file: .devcontainer/Dockerfile
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=${{ matrix.cache_scope }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.cache_scope }}
           platforms: ${{ matrix.platform }}
           push: ${{ github.ref_name == 'main' }}
           tags: ${{ steps.meta.outputs.tags }}


### PR DESCRIPTION
## What changed

- Builds `linux/arm64` on GitHub's native `ubuntu-24.04-arm` runner.
- Keeps `linux/amd64` on `ubuntu-latest`.
- Removes QEMU setup from the Docker workflow.
- Keeps the standard `type=gha` Docker cache configuration.

## Why

The Symphony and Ubuntu fixes from #201 restored prebuilt Erlang, but the arm64 Docker job was still doing all remaining work through QEMU on an amd64 runner. Running the arm job on native hosted arm hardware removes that emulation cost.

## Impact

The Docker workflow still builds both platform images, with less workflow setup and much faster arm64 build time.

## Validation

- `actionlint .github/workflows/docker.yml`
- Docker workflow passed before the rebase on branch `investigate-docker-build-slowdown`: https://github.com/jasonmorganson/dotfiles/actions/runs/26829820807
- Previous native arm validation completed `linux/arm64` in 3m28s.
