### PR TITLE
[codex] Add Git core developer config defaults

### DIFF
--- a/home/dot_config/git/branch
+++ b/home/dot_config/git/branch
@@ -1,0 +1,2 @@
+[branch]
+    sort = -committerdate

--- a/home/dot_config/git/column
+++ b/home/dot_config/git/column
@@ -1,0 +1,2 @@
+[column]
+    ui = auto

--- a/home/dot_config/git/config
+++ b/home/dot_config/git/config
@@ -1,7 +1,9 @@
 [include]
     path = absorb
     path = alias
+    path = branch
     path = color
+    path = column
     path = commit
     path = core
     path = delta
@@ -10,6 +12,7 @@
     path = filter
     path = gitalias
     path = help
+    path = init
     path = interactive
     path = log
     path = merge

--- a/home/dot_config/git/core
+++ b/home/dot_config/git/core
@@ -1,2 +1,3 @@
 [core]
+    excludesFile = ~/.config/git/ignore
     pager = delta --diff-so-fancy

--- a/home/dot_config/git/core
+++ b/home/dot_config/git/core
@@ -1,3 +1,2 @@
 [core]
-    excludesFile = ~/.config/git/ignore
     pager = delta --diff-so-fancy

--- a/home/dot_config/git/diff
+++ b/home/dot_config/git/diff
@@ -2,3 +2,5 @@
     algorithm = histogram
     colorMoved = default
     colorMovedWS = allow-indentation-change
+    mnemonicPrefix = true
+    renames = true

--- a/home/dot_config/git/fetch
+++ b/home/dot_config/git/fetch
@@ -1,2 +1,4 @@
 [fetch]
+    all = true
     prune = true
+    pruneTags = true

--- a/home/dot_config/git/init
+++ b/home/dot_config/git/init
@@ -1,0 +1,2 @@
+[init]
+    defaultBranch = main

--- a/home/dot_config/git/push
+++ b/home/dot_config/git/push
@@ -1,3 +1,4 @@
 [push]
     default = current
     autoSetupRemote = true
+    followTags = true

--- a/home/dot_config/git/rerere
+++ b/home/dot_config/git/rerere
@@ -1,2 +1,3 @@
 [rerere]
+    autoUpdate = true
     enabled = true

--- a/home/dot_config/git/tag
+++ b/home/dot_config/git/tag
@@ -1,2 +1,3 @@
 [tag]
     gpgSign = true
+    sort = version:refname


### PR DESCRIPTION
## Summary

- Add modular Git config files for branch, column, and init defaults from the GitButler core Git developer config recommendations.
- Add missing diff, fetch, push, rerere, and tag defaults to the existing chezmoi Git config split.
- Keep existing intentional local choices intact, including `push.default = current`, `diff.colorMoved = default`, and `help.autocorrect = immediate`.
- Remove the redundant explicit `core.excludesFile` setting because Git already defaults to `~/.config/git/ignore`.

## Validation

- Verified the checked-in modular config with `git config --file home/dot_config/git/config --includes` for the added keys.
- Ran `git diff --check -- home/dot_config/git` before committing the config additions.