### PR TITLE
Install Symphony through mise releases

### DIFF
--- a/home/.config/mise/config.toml
+++ b/home/.config/mise/config.toml
@@ -43,14 +43,7 @@ fish = true
 run = "mkdir -p ~/.local/state/bash/sessions ~/.config/claude ~/.config/codex ~/.config/docker"
 
 [bootstrap.hooks.post-tools]
-run = '''
-legacy_symphony="$HOME/.local/bin/symphony"
-if [ -f "$legacy_symphony" ] && grep -Fqx 'exec "$XDG_DATA_HOME/symphony/elixir/bin/symphony" "$@"' "$legacy_symphony"; then
-    rm "$legacy_symphony"
-fi
-
-mise exec -- ~/.local/libexec/mise/rc
-'''
+run = "mise exec -- ~/.local/libexec/mise/rc"
 
 [bootstrap.hooks.final]
 run = '''

--- a/home/.config/mise/config.toml
+++ b/home/.config/mise/config.toml
@@ -19,6 +19,7 @@ delta = "latest"
 "github:lsd-rs/lsd" = "latest"
 "aqua:BurntSushi/ripgrep" = "latest"
 "github:max-sixty/worktrunk" = "latest"
+"github:openai/symphony" = { version = "latest", bin = "symphony" }
 
 [tools."github:MitMaro/git-interactive-rebase-tool"]
 version = "latest"
@@ -32,7 +33,6 @@ linux-arm64 = { asset_pattern = "git-interactive-rebase-tool-*-ubuntu-*_arm64.de
 "~/.local/share/dotfiles" = { url = "https://github.com/jasonmorganson/dotfiles.git", ref = "main" }
 "~/.local/share/mise/repos/gitalias" = { url = "https://github.com/GitAlias/gitalias.git", ref = "main" }
 "~/.config/nushell/scripts/nu_scripts" = { url = "https://github.com/nushell/nu_scripts.git" }
-"~/.local/share/symphony" = { url = "https://github.com/openai/symphony.git" }
 
 [bootstrap.mise_shell_activate]
 zsh = true
@@ -43,7 +43,14 @@ fish = true
 run = "mkdir -p ~/.local/state/bash/sessions ~/.config/claude ~/.config/codex ~/.config/docker"
 
 [bootstrap.hooks.post-tools]
-run = "mise exec -- ~/.local/libexec/mise/rc"
+run = '''
+legacy_symphony="$HOME/.local/bin/symphony"
+if [ -f "$legacy_symphony" ] && grep -Fqx 'exec "$XDG_DATA_HOME/symphony/elixir/bin/symphony" "$@"' "$legacy_symphony"; then
+    rm "$legacy_symphony"
+fi
+
+mise exec -- ~/.local/libexec/mise/rc
+'''
 
 [bootstrap.hooks.final]
 run = '''
@@ -108,7 +115,6 @@ done
 "~/.docker" = { source = "~/.config/docker", mode = "symlink" }
 "~/.hushlogin" = { mode = "copy" }
 "~/.local/libexec/mise/rc" = { mode = "copy" }
-"~/.local/bin/symphony" = { mode = "copy" }
 "~/.ssh/config" = { mode = "copy" }
 "~/.zshrc/local" = { block = '[[ -f "$HOME/.config/zsh/rc" ]] && . "$HOME/.config/zsh/rc"' }
 "~/Library/Application Support/nushell" = { source = "~/.config/nushell", mode = "symlink" }
@@ -121,23 +127,6 @@ gh api "users/${GITHUB_USER}" --template '{% raw %}{{printf "[user]\n    name = 
 gh api "users/${GITHUB_USER}/keys" --jq '.[].key' | tee ~/.ssh/authorized_keys | sed "s/^/${GITHUB_USER} /" > ~/.ssh/allowed_signers
 grep -q '^github.com ' ~/.ssh/known_hosts 2>/dev/null || ssh-keyscan github.com >> ~/.ssh/known_hosts 2>/dev/null
 grep -q '^\[ssh.github.com\]:443 ' ~/.ssh/known_hosts 2>/dev/null || ssh-keyscan -p 443 ssh.github.com >> ~/.ssh/known_hosts 2>/dev/null
-
-symphony="$HOME/.local/share/symphony"
-stamp="$HOME/.local/state/mise/bootstrap/symphony-head"
-
-[ -d "$symphony/elixir" ] || exit 0
-
-head="$(cd "$symphony" && git rev-parse HEAD)"
-[ "$(cat "$stamp" 2>/dev/null || :)" != "$head" ] || exit 0
-
-cd "$symphony/elixir"
-export MISE_LOCKED=0
-mise trust
-mise install
-mise exec -- mix setup
-mise exec -- mix build
-mkdir -p "$(dirname "$stamp")"
-printf '%s\n' "$head" > "$stamp"
 '''
 
 [env]

--- a/home/.config/mise/mise.lock
+++ b/home/.config/mise/mise.lock
@@ -452,6 +452,30 @@ checksum = "sha256:5201aae6aacae94f8e81d5d73a7b46150a0d46577a10eef784c500e772416
 url = "https://github.com/max-sixty/worktrunk/releases/download/v0.68.0/worktrunk-x86_64-pc-windows-msvc.zip"
 url_api = "https://api.github.com/repos/max-sixty/worktrunk/releases/assets/478537409"
 
+[[tools."github:openai/symphony"]]
+version = "0.0.1"
+backend = "github:openai/symphony"
+
+[tools."github:openai/symphony"."platforms.linux-arm64"]
+checksum = "sha256:ce293ae26a90eb58c03b495f09ce2bee5f80a8546e597fa758b6294dd3e61249"
+url = "https://github.com/openai/symphony/releases/download/v0.0.1/symphony-v0.0.1-linux_arm64"
+url_api = "https://api.github.com/repos/openai/symphony/releases/assets/480957585"
+
+[tools."github:openai/symphony"."platforms.linux-x64"]
+checksum = "sha256:3ee54d44948f1c8a283d0bf377d8d729c01a9ce1da61e002cf593946daba688c"
+url = "https://github.com/openai/symphony/releases/download/v0.0.1/symphony-v0.0.1-linux_x86_64"
+url_api = "https://api.github.com/repos/openai/symphony/releases/assets/480957582"
+
+[tools."github:openai/symphony"."platforms.macos-arm64"]
+checksum = "sha256:e75cb8badada6dd8ed1f65fba808773ddbd8461d357b2fd2943f96df35d92eb9"
+url = "https://github.com/openai/symphony/releases/download/v0.0.1/symphony-v0.0.1-macos_arm64"
+url_api = "https://api.github.com/repos/openai/symphony/releases/assets/480957575"
+
+[tools."github:openai/symphony"."platforms.macos-x64"]
+checksum = "sha256:e854b806582ae3059f97a9bae7ae91c8f63f3e9e4f44e9623ef449f565b70ac5"
+url = "https://github.com/openai/symphony/releases/download/v0.0.1/symphony-v0.0.1-macos_x86_64"
+url_api = "https://api.github.com/repos/openai/symphony/releases/assets/480957608"
+
 [[tools.gitui]]
 version = "0.28.1"
 backend = "asdf:gitui"

--- a/home/.local/bin/symphony
+++ b/home/.local/bin/symphony
@@ -1,4 +1,0 @@
-#!/usr/bin/env -S mise exec erlang@28 -- /bin/sh
-set -eu
-
-exec "$XDG_DATA_HOME/symphony/elixir/bin/symphony" "$@"


### PR DESCRIPTION
## Summary

- Replace the locally built Symphony checkout and wrapper with mise-managed release binaries
- Pin Symphony release metadata and checksums in `mise.lock`
- Remove obsolete bootstrap, symlink, and build logic

## Testing

- Not run (not requested)