### PR TITLE
Refresh repositories before bootstrap

### DIFF
--- a/home/.config/mise/config.toml
+++ b/home/.config/mise/config.toml
@@ -276,7 +276,7 @@ TERMINFO_DIRS = "{{ env.XDG_DATA_HOME }}/terminfo:/usr/share/terminfo"
 
 # dotfiles
 dotfiles = "mise dotfiles"
-bootstrap = "mise bootstrap --yes --force-dotfiles"
+bootstrap = "mise bootstrap repos apply --yes && mise bootstrap --yes --force-dotfiles"
 
 # Habits
 ag = "rg"


### PR DESCRIPTION
Updates the `bootstrap` shell alias to refresh managed repositories first, then starts a new bootstrap process so updated mise configuration is loaded before dotfiles are applied.\n\nValidated with `mise config get shell_alias.bootstrap`, `mise shell-alias ls`, and `git diff --check`.