### PR TITLE
Add credential-free machine bootstrap

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -6,8 +6,7 @@ USER vscode
 
 COPY --chown=vscode:vscode . /tmp/dotfiles
 
-RUN --mount=type=secret,id=GITHUB_TOKEN,env=GITHUB_TOKEN,required=true \
-    --mount=type=secret,id=GITHUB_USER,env=GITHUB_USER,required=true \
+RUN --mount=type=secret,id=GITHUB_USER,env=GITHUB_USER,required=true \
     /tmp/dotfiles/install.sh
 
 WORKDIR /home/vscode

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -44,5 +44,4 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           secrets: |
-            GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
             GITHUB_USER=${{ github.repository_owner }}

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -3,7 +3,6 @@ name: Test install script
 on: push
 
 env:
-  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   GITHUB_USER: ${{ github.repository_owner }}
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -2,14 +2,24 @@
 
 Dotfiles, bootstrapped with [`mise`](https://mise.jdx.dev/).
 
-## Setup ##
+## Setup
 
-### Run setup script ###
-> `curl -L http://morganson.tools | sh`
+Bootstrap a new machine without GitHub authentication, providing the GitHub
+username whose public profile and SSH keys should be used:
+
+```sh
+curl -fsSL https://git.io/JJif9 | GITHUB_USER=your-github-user sh
+```
 
 [Source](https://gist.github.com/jasonmorganson/8a6fae35533bba8594a3e05e0bbe2f4d)
 
-## Usage ##
+## Usage
+
+Pull the latest dotfiles and reapply the machine configuration:
+
+```sh
+bootstrap
+```
 
 `install.sh` is the no-argument setup entrypoint used by Codespaces and similar
 environments. It installs `mise` to `/usr/local/bin` before bootstrapping:
@@ -18,6 +28,6 @@ environments. It installs `mise` to `/usr/local/bin` before bootstrapping:
 
 See [reference](https://mise.jdx.dev/).
 
-### Docker Compose ###
+### Docker Compose
 
 `docker-compose run dotfiles`

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,14 +2,24 @@
 
 Dotfiles, bootstrapped with [`mise`](https://mise.jdx.dev/).
 
-## Setup ##
+## Setup
 
-### Run setup script ###
-> `curl -sL https://git.io/JJif9 | sh`
+Bootstrap a new machine without GitHub authentication, providing the GitHub
+username whose public profile and SSH keys should be used:
+
+```sh
+curl -fsSL https://git.io/JJif9 | GITHUB_USER=your-github-user sh
+```
 
 [Source](https://gist.github.com/jasonmorganson/8a6fae35533bba8594a3e05e0bbe2f4d)
 
-## Usage ##
+## Usage
+
+Pull the latest dotfiles and reapply the machine configuration:
+
+```sh
+bootstrap
+```
 
 `install.sh` is the no-argument setup entrypoint used by Codespaces and similar
 environments. It installs `mise` to `/usr/local/bin` before bootstrapping:

--- a/docs/_coverpage.md
+++ b/docs/_coverpage.md
@@ -1,4 +1,4 @@
 # [~/.&nbsp;📂](https://github.com/jasonmorganson/dotfiles)
 # [dotfiles](https://github.com/jasonmorganson/dotfiles)
 
-# `curl -L morganson.tools | sh`
+# `curl -fsSL https://git.io/JJif9 | GITHUB_USER=your-github-user sh`

--- a/home/.config/mise/config.toml
+++ b/home/.config/mise/config.toml
@@ -12,6 +12,7 @@ fnox = "latest"
 helix = "latest"
 gitui = "latest"
 git-lfs = "latest"
+jaq = "latest"
 pitchfork = "latest"
 starship = "latest"
 vivid = "latest"
@@ -109,7 +110,7 @@ done
 [tasks.bootstrap]
 description = "Generate dynamic dotfiles and prepare local checkouts after mise tools are installed."
 run = '''
-set -u
+set -eu
 
 render_shell() {
     shell=$1
@@ -135,9 +136,20 @@ render_shell fish > "$HOME/.config/fish/conf.d/local.fish"
     wt config shell init nu
 } > "$HOME/.config/nushell/config.nu"
 
-GITHUB_USER="${GITHUB_USER:-$(gh api user --jq .login)}"
-gh api "users/${GITHUB_USER}" --template '{% raw %}{{printf "[user]\n    name = %q\n    email = %q\n    signingkey = ~/.ssh/id_ed25519.pub\n" .name (printf "%v+%s@users.noreply.github.com" .id .login)}}{% endraw %}' > ~/.config/git/user
-gh api "users/${GITHUB_USER}/keys" --jq '.[].key' | tee ~/.ssh/authorized_keys | sed "s/^/${GITHUB_USER} /" > ~/.ssh/allowed_signers
+: "${GITHUB_USER:?Set GITHUB_USER to your GitHub username}"
+profile=$(curl -fsSL "https://api.github.com/users/${GITHUB_USER}")
+keys=$(curl -fsSL "https://github.com/${GITHUB_USER}.keys")
+git_user=$(printf '%s\n' "$profile" | jaq -r '
+    "[user]",
+    "    name = \((.name // .login) | @json)",
+    "    email = \(((.id | tostring) + "+" + .login + "@users.noreply.github.com") | @json)",
+    "    signingkey = ~/.ssh/id_ed25519.pub"
+')
+allowed_signers=$(printf '%s' "$keys" | sed "s/^/${GITHUB_USER} /")
+
+printf '%s\n' "$git_user" > ~/.config/git/user
+printf '%s' "$keys" > ~/.ssh/authorized_keys
+printf '%s' "$allowed_signers" > ~/.ssh/allowed_signers
 grep -q '^github.com ' ~/.ssh/known_hosts 2>/dev/null || ssh-keyscan github.com >> ~/.ssh/known_hosts 2>/dev/null
 grep -q '^\[ssh.github.com\]:443 ' ~/.ssh/known_hosts 2>/dev/null || ssh-keyscan -p 443 ssh.github.com >> ~/.ssh/known_hosts 2>/dev/null
 '''

--- a/home/.config/mise/mise.lock
+++ b/home/.config/mise/mise.lock
@@ -508,6 +508,30 @@ checksum = "sha256:5c8325ced8bacd8418d62706f669e96d9c3578a9237526e34d546900cbc04
 url = "https://github.com/helix-editor/helix/releases/download/25.07.1/helix-25.07.1-x86_64-windows.zip"
 url_api = "https://api.github.com/repos/helix-editor/helix/releases/assets/274144377"
 
+[[tools.jaq]]
+version = "3.1.0"
+backend = "aqua:01mf02/jaq"
+
+[tools.jaq."platforms.linux-arm64"]
+checksum = "sha256:80fbbb82008d5f4dd3bb378740faf784445184429f2ba082e6b1fbf76360c251"
+url = "https://github.com/01mf02/jaq/releases/download/v3.1.0/jaq-aarch64-unknown-linux-gnu"
+url_api = "https://api.github.com/repos/01mf02/jaq/releases/assets/444870533"
+
+[tools.jaq."platforms.linux-x64"]
+checksum = "sha256:e860b9d74cdc5a55327415ba7b7897843dbfb74aa2d1ebfe15f27102848104ea"
+url = "https://github.com/01mf02/jaq/releases/download/v3.1.0/jaq-x86_64-unknown-linux-musl"
+url_api = "https://api.github.com/repos/01mf02/jaq/releases/assets/444869703"
+
+[tools.jaq."platforms.macos-arm64"]
+checksum = "sha256:56dd7006a4d8d9d5a0b599fba844e94fc9c4013551a0c997cf93e0950dd3736d"
+url = "https://github.com/01mf02/jaq/releases/download/v3.1.0/jaq-aarch64-apple-darwin"
+url_api = "https://api.github.com/repos/01mf02/jaq/releases/assets/444870264"
+
+[tools.jaq."platforms.macos-x64"]
+checksum = "sha256:7ef31a6f506e23be8ffee1116a4764b8761628432928aea4db2e9b8a22c28999"
+url = "https://github.com/01mf02/jaq/releases/download/v3.1.0/jaq-x86_64-apple-darwin"
+url_api = "https://api.github.com/repos/01mf02/jaq/releases/assets/444870195"
+
 [[tools.pitchfork]]
 version = "2.17.0"
 backend = "aqua:jdx/pitchfork"


### PR DESCRIPTION
## Summary
- add the Rust-based `jaq` tool and locked downloads for supported platforms
- generate Git identity and SSH authorization files from public GitHub endpoints using externally supplied `GITHUB_USER`
- document the public new-machine and repeat-bootstrap flows
- remove GitHub token injection from install and Docker CI

## Validation
- credential-free bootstrap task in a blank home
- public API failure preserves existing identity and key files
- hosted wrapper clone, repeat, dirty-checkout, and diverged-checkout scenarios
- shellcheck, TOML resolution, lockfile platforms, YAML parsing, and diff checks