### PR TITLE
Use live bootstrap gist URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Bootstrap a new machine without GitHub authentication, providing the GitHub
 username whose public profile and SSH keys should be used:
 
 ```sh
-curl -fsSL https://git.io/JJif9 | GITHUB_USER=your-github-user sh
+curl -fsSL https://gist.github.com/jasonmorganson/8a6fae35533bba8594a3e05e0bbe2f4d/raw/setup.sh | GITHUB_USER=your-github-user sh
 ```
 
 [Source](https://gist.github.com/jasonmorganson/8a6fae35533bba8594a3e05e0bbe2f4d)

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,7 +8,7 @@ Bootstrap a new machine without GitHub authentication, providing the GitHub
 username whose public profile and SSH keys should be used:
 
 ```sh
-curl -fsSL https://git.io/JJif9 | GITHUB_USER=your-github-user sh
+curl -fsSL https://gist.github.com/jasonmorganson/8a6fae35533bba8594a3e05e0bbe2f4d/raw/setup.sh | GITHUB_USER=your-github-user sh
 ```
 
 [Source](https://gist.github.com/jasonmorganson/8a6fae35533bba8594a3e05e0bbe2f4d)

--- a/docs/_coverpage.md
+++ b/docs/_coverpage.md
@@ -1,4 +1,4 @@
 # [~/.&nbsp;📂](https://github.com/jasonmorganson/dotfiles)
 # [dotfiles](https://github.com/jasonmorganson/dotfiles)
 
-# `curl -fsSL https://git.io/JJif9 | GITHUB_USER=your-github-user sh`
+# `curl -fsSL https://gist.github.com/jasonmorganson/8a6fae35533bba8594a3e05e0bbe2f4d/raw/setup.sh | GITHUB_USER=your-github-user sh`


### PR DESCRIPTION
The legacy `git.io/JJif9` URL is pinned to the old chezmoi gist revision. Point setup documentation at the revisionless raw gist URL so it serves the new credential-free bootstrap and follows future gist updates.\n\nValidated the live response with POSIX syntax checking, ShellCheck, and a check that no chezmoi content remains.