### PR TITLE
Use optional GitHub token in CI

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -6,7 +6,8 @@ USER vscode
 
 COPY --chown=vscode:vscode . /tmp/dotfiles
 
-RUN --mount=type=secret,id=GITHUB_USER,env=GITHUB_USER,required=true \
+RUN --mount=type=secret,id=GITHUB_TOKEN,env=GITHUB_TOKEN,required=true \
+    --mount=type=secret,id=GITHUB_USER,env=GITHUB_USER,required=true \
     /tmp/dotfiles/install.sh
 
 WORKDIR /home/vscode

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -44,4 +44,5 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           secrets: |
+            GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
             GITHUB_USER=${{ github.repository_owner }}

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -3,6 +3,7 @@ name: Test install script
 on: push
 
 env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   GITHUB_USER: ${{ github.repository_owner }}
 
 jobs:

--- a/home/.config/mise/config.toml
+++ b/home/.config/mise/config.toml
@@ -137,7 +137,15 @@ render_shell fish > "$HOME/.config/fish/conf.d/local.fish"
 } > "$HOME/.config/nushell/config.nu"
 
 : "${GITHUB_USER:?Set GITHUB_USER to your GitHub username}"
-profile=$(curl -fsSL "https://api.github.com/users/${GITHUB_USER}")
+github_api() {
+    if [ -n "${GITHUB_TOKEN:-}" ]; then
+        curl -fsSL -H "Authorization: Bearer ${GITHUB_TOKEN}" "$1"
+    else
+        curl -fsSL "$1"
+    fi
+}
+
+profile=$(github_api "https://api.github.com/users/${GITHUB_USER}")
 keys=$(curl -fsSL "https://github.com/${GITHUB_USER}.keys")
 git_user=$(printf '%s\n' "$profile" | jaq -r '
     "[user]",


### PR DESCRIPTION
Shared GitHub-hosted macOS runners exhausted anonymous API limits after the credential-free bootstrap landed. Restore the CI-provided token for mise artifact-attestation requests and use it for the public profile request when available, while retaining the unauthenticated curl path for new machines.\n\nValidated both authenticated and unauthenticated profile requests, the full unauthenticated bootstrap task, workflow YAML, and diff checks.