### PR TITLE
Fix local bootstrap sources and configure dotfiles root

### DIFF
--- a/home/.config/mise/config.toml
+++ b/home/.config/mise/config.toml
@@ -1,5 +1,6 @@
 [settings]
 locked = true
+dotfiles.root = "~/.local/share/dotfiles/home"
 
 [tools]
 gh = "latest"


### PR DESCRIPTION
## Summary

- Pass the GitHub username as a positional argument in bootstrap documentation.
- Configure mise to use the local dotfiles root.

## Testing

- Not run (not requested).