### PR TITLE
Skip bot GitHub identities

### DIFF
--- a/home/.config/mise/config.toml
+++ b/home/.config/mise/config.toml
@@ -137,7 +137,9 @@ render_shell fish > "$HOME/.config/fish/conf.d/local.fish"
     wt config shell init nu
 } > "$HOME/.config/nushell/config.nu"
 
-GITHUB_USER=${GITHUB_USER:-$(gh api user --jq .login 2>/dev/null || true)}
+if [ -z "${GITHUB_USER:-}" ]; then
+    GITHUB_USER=$(gh api user --jq 'select(.type == "User") | .login' 2>/dev/null) || GITHUB_USER=
+fi
 if [ -n "$GITHUB_USER" ]; then
     github_api() {
         if [ -n "${GITHUB_TOKEN:-}" ]; then


### PR DESCRIPTION
## What changed

- Infer `GITHUB_USER` only when the authenticated GitHub account is a human user.
- Treat bot or unavailable authentication as no username so bootstrap skips the optional identity refresh.
- Preserve explicit `GITHUB_USER` behavior.

## Why

The no-user bootstrap regression test still had GitHub Actions' token available. `gh api user` returned `github-actions[bot]`, which was then interpolated into public profile and key URLs and caused the bootstrap task to fail.

## Validation

- Ran bootstrap with `GITHUB_USER` unset and unavailable authentication; existing identity files remained unchanged.
- Ran bootstrap with `GITHUB_USER` unset and authenticated human GitHub CLI access; identity refresh succeeded.
- Verified the account-type filter excludes `github-actions[bot]`.
- Ran `git diff --check`.
