### PR TITLE
Adopt safer Git defaults and Git 3 compatibility settings

### DIFF
--- a/home/.config/git/config
+++ b/home/.config/git/config
@@ -20,8 +20,10 @@
     path = push
     path = rebase
     path = rerere
+    path = safe
     path = sequence
     path = tag
+    path = transfer
 
 [includeIf "gitdir:~/"]
     path = gpg

--- a/home/.config/git/fetch
+++ b/home/.config/git/fetch
@@ -2,3 +2,4 @@
     all = true
     prune = true
     pruneTags = true
+    writeCommitGraph = true

--- a/home/.config/git/init
+++ b/home/.config/git/init
@@ -1,2 +1,5 @@
+# Git 3 compatibility pins: https://git-scm.com/docs/BreakingChanges
 [init]
     defaultBranch = main
+    defaultObjectFormat = sha1
+    defaultRefFormat = files

--- a/home/.config/git/push
+++ b/home/.config/git/push
@@ -2,3 +2,4 @@
     default = current
     autoSetupRemote = true
     followTags = true
+    useForceIfIncludes = true

--- a/home/.config/git/safe
+++ b/home/.config/git/safe
@@ -1,0 +1,4 @@
+# Adopt Git 3's safer bare-repository discovery behavior ahead of the default.
+# https://git-scm.com/docs/BreakingChanges
+[safe]
+    bareRepository = explicit

--- a/home/.config/git/transfer
+++ b/home/.config/git/transfer
@@ -1,0 +1,2 @@
+[transfer]
+    credentialsInUrl = warn

--- a/home/.config/mise/conf.d/30-dotfiles.toml
+++ b/home/.config/mise/conf.d/30-dotfiles.toml
@@ -41,8 +41,10 @@
 "~/.config/git/push" = { mode = "copy" }
 "~/.config/git/rebase" = { mode = "copy" }
 "~/.config/git/rerere" = { mode = "copy" }
+"~/.config/git/safe" = { mode = "copy" }
 "~/.config/git/sequence" = { mode = "copy" }
 "~/.config/git/tag" = { mode = "copy" }
+"~/.config/git/transfer" = { mode = "copy" }
 "~/.config/nushell/autoload/preferences.nu" = { mode = "copy" }
 "~/.config/pitchfork/config.toml" = { mode = "copy" }
 "~/.config/readline/inputrc" = { mode = "copy" }


### PR DESCRIPTION
## Summary

- Add Git 3 compatibility pins for object and ref formats.
- Enable safer bare-repository discovery and credential URL warnings.
- Enable commit-graph writes and safer force-push behavior.
- Register the new Git configuration files with mise.

## Testing

- Not run (not requested)