### PR TITLE
Move dotfiles tests into mise tasks and run them in CI

### DIFF
--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -1,6 +1,8 @@
 name: Test install script
 
-on: push
+on:
+  push:
+    branches: [main]
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -1,8 +1,6 @@
 name: Test install script
 
-on:
-  push:
-    branches: [main]
+on: push
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,9 +11,5 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: jdx/mise-action@v4
-        with:
-          version: 2026.8.12
-          install: false
-          cache: false
       - name: Run tests
         run: mise run test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,19 @@
+name: Test pull request
+
+on: pull_request
+
+env:
+  MISE_CONFIG_DIR: ${{ github.workspace }}/home/.config/mise
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: jdx/mise-action@v4
+        with:
+          version: 2026.8.12
+          install: false
+          cache: false
+      - name: Run tests
+        run: mise run test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: Test pull request
+name: Test
 
 on: pull_request
 

--- a/home/.config/mise/conf.d/30-dotfiles.toml
+++ b/home/.config/mise/conf.d/30-dotfiles.toml
@@ -13,6 +13,7 @@
 "~/.config/mise/mise.lock" = { mode = "symlink" }
 "~/.config/mise/miserc.toml" = { mode = "symlink" }
 "~/.config/mise/tasks/bootstrap" = { mode = "symlink" }
+"~/.config/mise/tasks/test" = { mode = "symlink" }
 "~/.bash_profile/local" = { block = '[[ -f "$HOME/.bashrc" ]] && . "$HOME/.bashrc"' }
 "~/.bashrc/local" = { block = '[[ -f "$HOME/.config/bash/rc" ]] && . "$HOME/.config/bash/rc"' }
 "~/.config/fish/conf.d/preferences.fish" = { mode = "copy" }

--- a/home/.config/mise/tasks/test/_default
+++ b/home/.config/mise/tasks/test/_default
@@ -1,0 +1,6 @@
+#!/bin/sh
+#MISE description="Run all dotfiles tests."
+#MISE depends=["test:*"]
+set -eu
+
+echo "all dotfiles tests passed"

--- a/home/.config/mise/tasks/test/touch-id-sudo
+++ b/home/.config/mise/tasks/test/touch-id-sudo
@@ -1,0 +1,31 @@
+#!/bin/sh
+#MISE description="Verify the macOS Touch ID sudo bootstrap declaration."
+set -eu
+
+repo_root="$(CDPATH= cd -P -- "$MISE_TASK_DIR/../../../../.." && pwd)"
+platform_config="$repo_root/home/.config/mise/config.macos.toml"
+source_file="$repo_root/home/.config/mise/files/etc/pam.d/sudo_local"
+dotfiles="$repo_root/home/.config/mise/conf.d/30-dotfiles.toml"
+miserc="$repo_root/home/.config/mise/miserc.toml"
+
+grep -Fxq 'auto_env = true' "$miserc" ||
+    { echo "mise must enable platform-specific configuration" >&2; exit 1; }
+
+grep -Fq '[bootstrap.files."/etc/pam.d/sudo_local"]' "$platform_config" ||
+    { echo "Touch ID sudo override must be managed by bootstrap.files" >&2; exit 1; }
+grep -Fxq 'source = "files/etc/pam.d/sudo_local"' "$platform_config" ||
+    { echo "Touch ID sudo override must use the checked-in source" >&2; exit 1; }
+grep -Fxq 'owner = "root"' "$platform_config" ||
+    { echo "Touch ID sudo override must be root-owned" >&2; exit 1; }
+grep -Fxq 'group = "wheel"' "$platform_config" ||
+    { echo "Touch ID sudo override must use macOS wheel group" >&2; exit 1; }
+grep -Fxq 'mode = "0444"' "$platform_config" ||
+    { echo "Touch ID sudo override must preserve Apple template permissions" >&2; exit 1; }
+grep -Fxq 'auth       sufficient     pam_tid.so' "$source_file" ||
+    { echo "Touch ID sudo override must enable pam_tid" >&2; exit 1; }
+grep -Fq '"~/.config/mise/config.macos.toml" = { mode = "symlink" }' "$dotfiles" ||
+    { echo "macOS mise config must be dotfiles-managed" >&2; exit 1; }
+grep -Fq '"~/.config/mise/miserc.toml" = { mode = "symlink" }' "$dotfiles" ||
+    { echo "mise early-init config must be dotfiles-managed" >&2; exit 1; }
+
+echo "Touch ID sudo bootstrap fixtures passed"

--- a/home/.config/mise/tasks/test/zsh-bootstrap
+++ b/home/.config/mise/tasks/test/zsh-bootstrap
@@ -1,7 +1,8 @@
 #!/bin/sh
+#MISE description="Verify zsh bootstrap ownership and ordering."
 set -eu
 
-repo_root="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)"
+repo_root="$(CDPATH= cd -P -- "$MISE_TASK_DIR/../../../../.." && pwd)"
 zshrc="$repo_root/home/.config/zsh/.zshrc"
 dotfiles="$repo_root/home/.config/mise/conf.d/30-dotfiles.toml"
 bootstrap="$repo_root/home/.config/mise/tasks/bootstrap"


### PR DESCRIPTION
## Summary

- Add a pull request workflow that runs the complete dotfiles test suite through mise.
- Move the zsh bootstrap test into the managed mise task hierarchy.
- Add coverage for the macOS Touch ID sudo bootstrap declaration.
- Register the new test tasks with dotfiles management.

## Testing

- Added mise tasks for the aggregate suite, zsh bootstrap validation, and Touch ID sudo checks.
- CI runs `mise run test` for pull requests.