### PR TITLE
Use standard user-local mise installation

### DIFF
--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -18,4 +18,4 @@ jobs:
     - name: Run install script
       run: ./install.sh
     - name: Re-run bootstrap without GitHub user
-      run: env -u GITHUB_USER /usr/local/bin/mise run bootstrap
+      run: env -u GITHUB_USER "$HOME/.local/bin/mise" run bootstrap

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ rm -rf "$repo"
 mkdir -p "${repo%/*}"
 git clone https://github.com/jasonmorganson/dotfiles.git "$repo"
 "$repo/install.sh"
-/usr/local/bin/mise set --file "$HOME/.config/mise/config.local.toml" "GITHUB_USER=$GITHUB_USER"
+"$HOME/.local/bin/mise" set --file "$HOME/.config/mise/config.local.toml" "GITHUB_USER=$GITHUB_USER"
 ```
 
 ## Usage
@@ -38,7 +38,8 @@ bootstrap
 ```
 
 `install.sh` is the no-argument setup entrypoint used by Codespaces and similar
-environments. It installs `mise` to `/usr/local/bin` before bootstrapping:
+environments. It installs `mise` to its standard user-local path before
+bootstrapping:
 
 > `mise bootstrap --yes --force-dotfiles`
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -26,7 +26,7 @@ rm -rf "$repo"
 mkdir -p "${repo%/*}"
 git clone https://github.com/jasonmorganson/dotfiles.git "$repo"
 "$repo/install.sh"
-/usr/local/bin/mise set --file "$HOME/.config/mise/config.local.toml" "GITHUB_USER=$GITHUB_USER"
+"$HOME/.local/bin/mise" set --file "$HOME/.config/mise/config.local.toml" "GITHUB_USER=$GITHUB_USER"
 ```
 
 ## Usage
@@ -38,7 +38,8 @@ bootstrap
 ```
 
 `install.sh` is the no-argument setup entrypoint used by Codespaces and similar
-environments. It installs `mise` to `/usr/local/bin` before bootstrapping:
+environments. It installs `mise` to its standard user-local path before
+bootstrapping:
 
 > `mise bootstrap --yes --force-dotfiles`
 

--- a/home/.config/mise/tasks/test/install
+++ b/home/.config/mise/tasks/test/install
@@ -1,0 +1,20 @@
+#!/bin/sh
+#MISE description="Verify the no-argument user-local installation entrypoint."
+set -eu
+
+repo_root="$(CDPATH= cd -P -- "$MISE_TASK_DIR/../../../../.." && pwd)"
+installer="$repo_root/install.sh"
+
+grep -Fq 'cd "$(dirname "$0")"' "$installer" ||
+    { echo "installer must resolve paths from its own directory" >&2; exit 1; }
+grep -Fq 'curl -fsSL https://mise.run | sh' "$installer" ||
+    { echo "installer must use the standard mise installer" >&2; exit 1; }
+grep -Fq '"$HOME/.local/bin/mise" bootstrap --yes --force-dotfiles' "$installer" ||
+    { echo "installer must bootstrap through the user-local mise binary" >&2; exit 1; }
+
+if grep -Eq 'sudo|MISE_INSTALL_PATH|/usr/local/bin/mise' "$installer"; then
+    echo "installer must not require a privileged or custom mise installation" >&2
+    exit 1
+fi
+
+echo "mise install entrypoint fixtures passed"

--- a/home/.config/mise/tasks/test/zsh-bootstrap
+++ b/home/.config/mise/tasks/test/zsh-bootstrap
@@ -11,10 +11,10 @@ environment_config="$repo_root/home/.config/mise/conf.d/40-env.toml"
 aliases_config="$repo_root/home/.config/mise/conf.d/50-aliases.toml"
 mise_config="$repo_root/home/.config/mise/config.toml"
 
-grep -Fq 'eval "$(/usr/local/bin/mise activate zsh)"' "$zshrc" ||
-    { echo "zsh must activate through /usr/local/bin/mise" >&2; exit 1; }
+grep -Fq 'eval "$("$HOME/.local/bin/mise" activate zsh)"' "$zshrc" ||
+    { echo "zsh must activate through the standard user-local mise path" >&2; exit 1; }
 
-activation_line="$(grep -nF '/usr/local/bin/mise activate zsh' "$zshrc" | cut -d: -f1)"
+activation_line="$(grep -nF '$HOME/.local/bin/mise" activate zsh' "$zshrc" | cut -d: -f1)"
 integration_line="$(grep -nF '$HOME/.config/zsh/rc' "$zshrc" | cut -d: -f1)"
 [ "$activation_line" -lt "$integration_line" ] ||
     { echo "mise must activate before generated tool integrations" >&2; exit 1; }

--- a/home/.config/zsh/.zshrc
+++ b/home/.config/zsh/.zshrc
@@ -1,6 +1,6 @@
-# Keep the machine-wide mise entrypoint stable; mise then selects the current
-# user-managed tools before their generated integrations are sourced.
-eval "$(/usr/local/bin/mise activate zsh)"
+# Activate the standard user-local mise installation before generated tool
+# integrations are sourced.
+eval "$("$HOME/.local/bin/mise" activate zsh)"
 
 [[ -f "$HOME/.config/zsh/rc" ]] && . "$HOME/.config/zsh/rc"
 [[ -f "$HOME/.config/zsh/preferences.zsh" ]] && . "$HOME/.config/zsh/preferences.zsh"

--- a/install.sh
+++ b/install.sh
@@ -2,8 +2,8 @@
 set -e
 
 cd "$(dirname "$0")"
-curl https://mise.run | sudo env MISE_INSTALL_PATH=/usr/local/bin/mise sh
+curl -fsSL https://mise.run | sh
 MISE_CONFIG_DIR="$PWD/home/.config/mise" \
 MISE_DOTFILES_ROOT="$PWD/home" \
 MISE_IGNORED_CONFIG_PATHS="$HOME/.local/share/dotfiles/home/.config/mise/config.toml" \
-/usr/local/bin/mise bootstrap --yes --force-dotfiles
+"$HOME/.local/bin/mise" bootstrap --yes --force-dotfiles


### PR DESCRIPTION
## Summary
- install mise at its standard user-local path without sudo
- keep the no-argument Codespaces installer and script-directory resolution
- align zsh activation, CI, documentation, and bootstrap fixtures

## Validation
- `mise run test`
- shell syntax validation for the installer and test tasks
- `git diff --check`