### PR TITLE
Simplify the documented setup flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,13 +19,11 @@ curl -fsSL https://gist.github.com/jasonmorganson/8a6fae35533bba8594a3e05e0bbe2f
 #!/bin/sh
 set -eu
 
-repo="$HOME/.local/share/dotfiles"
 export GITHUB_USER="${1:-${GITHUB_USER:?usage: setup.sh GITHUB_USERNAME}}"
 
-rm -rf "$repo"
-mkdir -p "${repo%/*}"
-git clone https://github.com/jasonmorganson/dotfiles.git "$repo"
-"$repo/install.sh"
+mkdir -p "$HOME/.local/share"
+git clone https://github.com/jasonmorganson/dotfiles.git "$HOME/.local/share/dotfiles"
+"$HOME/.local/share/dotfiles/install.sh"
 "$HOME/.local/bin/mise" set --file "$HOME/.config/mise/config.local.toml" "GITHUB_USER=$GITHUB_USER"
 ```
 

--- a/README.md
+++ b/README.md
@@ -4,23 +4,7 @@ Dotfiles, bootstrapped with [`mise`](https://mise.jdx.dev/).
 
 ## Setup
 
-Bootstrap a new machine without GitHub authentication. You can optionally export
-the GitHub username whose public profile and SSH keys should be used:
-
-```sh
-# Optional
-export GITHUB_USER="your-github-user"
-
-curl -fsSL https://gist.github.com/jasonmorganson/8a6fae35533bba8594a3e05e0bbe2f4d/raw/setup.sh | sh
-```
-
-When available, `GITHUB_USER` is used for the current bootstrap and is not stored
-in the mise config. Otherwise, bootstrap detects the authenticated GitHub CLI
-user when possible.
-
-[Source](https://gist.github.com/jasonmorganson/8a6fae35533bba8594a3e05e0bbe2f4d)
-
-### Setup script
+Bootstrap a new machine with the following script:
 
 ```sh
 #!/bin/sh
@@ -30,6 +14,10 @@ mkdir -p "$HOME/.local/share"
 git clone https://github.com/jasonmorganson/dotfiles.git "$HOME/.local/share/dotfiles"
 "$HOME/.local/share/dotfiles/install.sh"
 ```
+
+You can optionally run `export GITHUB_USER="your-github-user"` first to use that
+GitHub profile and its SSH keys. The value is not stored in the mise config.
+Otherwise, bootstrap detects the authenticated GitHub CLI user when possible.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,6 @@ export GITHUB_USER="${1:-${GITHUB_USER:?usage: setup.sh GITHUB_USERNAME}}"
 mkdir -p "$HOME/.local/share"
 git clone https://github.com/jasonmorganson/dotfiles.git "$HOME/.local/share/dotfiles"
 "$HOME/.local/share/dotfiles/install.sh"
-"$HOME/.local/bin/mise" set --file "$HOME/.config/mise/config.local.toml" "GITHUB_USER=$GITHUB_USER"
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -4,18 +4,19 @@ Dotfiles, bootstrapped with [`mise`](https://mise.jdx.dev/).
 
 ## Setup
 
-Bootstrap a new machine without GitHub authentication. First, export the GitHub
-username whose public profile and SSH keys should be used, then run the setup
-script:
+Bootstrap a new machine without GitHub authentication. You can optionally export
+the GitHub username whose public profile and SSH keys should be used:
 
 ```sh
+# Optional
 export GITHUB_USER="your-github-user"
+
 curl -fsSL https://gist.github.com/jasonmorganson/8a6fae35533bba8594a3e05e0bbe2f4d/raw/setup.sh | sh
 ```
 
-`GITHUB_USER` is used for this bootstrap and is not stored in the mise config.
-Later bootstrap runs use it when available, or detect the authenticated GitHub
-CLI user.
+When available, `GITHUB_USER` is used for the current bootstrap and is not stored
+in the mise config. Otherwise, bootstrap detects the authenticated GitHub CLI
+user when possible.
 
 [Source](https://gist.github.com/jasonmorganson/8a6fae35533bba8594a3e05e0bbe2f4d)
 
@@ -24,8 +25,6 @@ CLI user.
 ```sh
 #!/bin/sh
 set -eu
-
-: "${GITHUB_USER:?set and export GITHUB_USER before running this script}"
 
 mkdir -p "$HOME/.local/share"
 git clone https://github.com/jasonmorganson/dotfiles.git "$HOME/.local/share/dotfiles"

--- a/README.md
+++ b/README.md
@@ -4,12 +4,18 @@ Dotfiles, bootstrapped with [`mise`](https://mise.jdx.dev/).
 
 ## Setup
 
-Bootstrap a new machine without GitHub authentication, providing the GitHub
-username whose public profile and SSH keys should be used:
+Bootstrap a new machine without GitHub authentication. First, export the GitHub
+username whose public profile and SSH keys should be used, then run the setup
+script:
 
 ```sh
-curl -fsSL https://gist.github.com/jasonmorganson/8a6fae35533bba8594a3e05e0bbe2f4d/raw/setup.sh | sh -s -- your-github-user
+export GITHUB_USER="your-github-user"
+curl -fsSL https://gist.github.com/jasonmorganson/8a6fae35533bba8594a3e05e0bbe2f4d/raw/setup.sh | sh
 ```
+
+`GITHUB_USER` is used for this bootstrap and is not stored in the mise config.
+Later bootstrap runs use it when available, or detect the authenticated GitHub
+CLI user.
 
 [Source](https://gist.github.com/jasonmorganson/8a6fae35533bba8594a3e05e0bbe2f4d)
 
@@ -19,7 +25,7 @@ curl -fsSL https://gist.github.com/jasonmorganson/8a6fae35533bba8594a3e05e0bbe2f
 #!/bin/sh
 set -eu
 
-export GITHUB_USER="${1:-${GITHUB_USER:?usage: setup.sh GITHUB_USERNAME}}"
+: "${GITHUB_USER:?set and export GITHUB_USER before running this script}"
 
 mkdir -p "$HOME/.local/share"
 git clone https://github.com/jasonmorganson/dotfiles.git "$HOME/.local/share/dotfiles"

--- a/docs/README.md
+++ b/docs/README.md
@@ -19,13 +19,11 @@ curl -fsSL https://gist.github.com/jasonmorganson/8a6fae35533bba8594a3e05e0bbe2f
 #!/bin/sh
 set -eu
 
-repo="$HOME/.local/share/dotfiles"
 export GITHUB_USER="${1:-${GITHUB_USER:?usage: setup.sh GITHUB_USERNAME}}"
 
-rm -rf "$repo"
-mkdir -p "${repo%/*}"
-git clone https://github.com/jasonmorganson/dotfiles.git "$repo"
-"$repo/install.sh"
+mkdir -p "$HOME/.local/share"
+git clone https://github.com/jasonmorganson/dotfiles.git "$HOME/.local/share/dotfiles"
+"$HOME/.local/share/dotfiles/install.sh"
 "$HOME/.local/bin/mise" set --file "$HOME/.config/mise/config.local.toml" "GITHUB_USER=$GITHUB_USER"
 ```
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,23 +4,7 @@ Dotfiles, bootstrapped with [`mise`](https://mise.jdx.dev/).
 
 ## Setup
 
-Bootstrap a new machine without GitHub authentication. You can optionally export
-the GitHub username whose public profile and SSH keys should be used:
-
-```sh
-# Optional
-export GITHUB_USER="your-github-user"
-
-curl -fsSL https://gist.github.com/jasonmorganson/8a6fae35533bba8594a3e05e0bbe2f4d/raw/setup.sh | sh
-```
-
-When available, `GITHUB_USER` is used for the current bootstrap and is not stored
-in the mise config. Otherwise, bootstrap detects the authenticated GitHub CLI
-user when possible.
-
-[Source](https://gist.github.com/jasonmorganson/8a6fae35533bba8594a3e05e0bbe2f4d)
-
-### Setup script
+Bootstrap a new machine with the following script:
 
 ```sh
 #!/bin/sh
@@ -30,6 +14,10 @@ mkdir -p "$HOME/.local/share"
 git clone https://github.com/jasonmorganson/dotfiles.git "$HOME/.local/share/dotfiles"
 "$HOME/.local/share/dotfiles/install.sh"
 ```
+
+You can optionally run `export GITHUB_USER="your-github-user"` first to use that
+GitHub profile and its SSH keys. The value is not stored in the mise config.
+Otherwise, bootstrap detects the authenticated GitHub CLI user when possible.
 
 ## Usage
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -24,7 +24,6 @@ export GITHUB_USER="${1:-${GITHUB_USER:?usage: setup.sh GITHUB_USERNAME}}"
 mkdir -p "$HOME/.local/share"
 git clone https://github.com/jasonmorganson/dotfiles.git "$HOME/.local/share/dotfiles"
 "$HOME/.local/share/dotfiles/install.sh"
-"$HOME/.local/bin/mise" set --file "$HOME/.config/mise/config.local.toml" "GITHUB_USER=$GITHUB_USER"
 ```
 
 ## Usage

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,18 +4,19 @@ Dotfiles, bootstrapped with [`mise`](https://mise.jdx.dev/).
 
 ## Setup
 
-Bootstrap a new machine without GitHub authentication. First, export the GitHub
-username whose public profile and SSH keys should be used, then run the setup
-script:
+Bootstrap a new machine without GitHub authentication. You can optionally export
+the GitHub username whose public profile and SSH keys should be used:
 
 ```sh
+# Optional
 export GITHUB_USER="your-github-user"
+
 curl -fsSL https://gist.github.com/jasonmorganson/8a6fae35533bba8594a3e05e0bbe2f4d/raw/setup.sh | sh
 ```
 
-`GITHUB_USER` is used for this bootstrap and is not stored in the mise config.
-Later bootstrap runs use it when available, or detect the authenticated GitHub
-CLI user.
+When available, `GITHUB_USER` is used for the current bootstrap and is not stored
+in the mise config. Otherwise, bootstrap detects the authenticated GitHub CLI
+user when possible.
 
 [Source](https://gist.github.com/jasonmorganson/8a6fae35533bba8594a3e05e0bbe2f4d)
 
@@ -24,8 +25,6 @@ CLI user.
 ```sh
 #!/bin/sh
 set -eu
-
-: "${GITHUB_USER:?set and export GITHUB_USER before running this script}"
 
 mkdir -p "$HOME/.local/share"
 git clone https://github.com/jasonmorganson/dotfiles.git "$HOME/.local/share/dotfiles"

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,12 +4,18 @@ Dotfiles, bootstrapped with [`mise`](https://mise.jdx.dev/).
 
 ## Setup
 
-Bootstrap a new machine without GitHub authentication, providing the GitHub
-username whose public profile and SSH keys should be used:
+Bootstrap a new machine without GitHub authentication. First, export the GitHub
+username whose public profile and SSH keys should be used, then run the setup
+script:
 
 ```sh
-curl -fsSL https://gist.github.com/jasonmorganson/8a6fae35533bba8594a3e05e0bbe2f4d/raw/setup.sh | sh -s -- your-github-user
+export GITHUB_USER="your-github-user"
+curl -fsSL https://gist.github.com/jasonmorganson/8a6fae35533bba8594a3e05e0bbe2f4d/raw/setup.sh | sh
 ```
+
+`GITHUB_USER` is used for this bootstrap and is not stored in the mise config.
+Later bootstrap runs use it when available, or detect the authenticated GitHub
+CLI user.
 
 [Source](https://gist.github.com/jasonmorganson/8a6fae35533bba8594a3e05e0bbe2f4d)
 
@@ -19,7 +25,7 @@ curl -fsSL https://gist.github.com/jasonmorganson/8a6fae35533bba8594a3e05e0bbe2f
 #!/bin/sh
 set -eu
 
-export GITHUB_USER="${1:-${GITHUB_USER:?usage: setup.sh GITHUB_USERNAME}}"
+: "${GITHUB_USER:?set and export GITHUB_USER before running this script}"
 
 mkdir -p "$HOME/.local/share"
 git clone https://github.com/jasonmorganson/dotfiles.git "$HOME/.local/share/dotfiles"


### PR DESCRIPTION
## Summary
- replace the Gist-based setup instructions with one self-contained clone and install block
- keep `GITHUB_USER` optional and avoid persisting it in mise configuration
- document authenticated GitHub CLI discovery as the fallback
- keep the generated documentation copy aligned with the root README

## Validation
- `git diff --check`
- verified no Gist references remain in either README copy