### PR TITLE
Simplify setup with a streamable installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,17 +7,19 @@ Dotfiles, bootstrapped with [`mise`](https://mise.jdx.dev/).
 Bootstrap a new machine with the following script:
 
 ```sh
-#!/bin/sh
-set -eu
-
-mkdir -p "$HOME/.local/share"
-git clone https://github.com/jasonmorganson/dotfiles.git "$HOME/.local/share/dotfiles"
-"$HOME/.local/share/dotfiles/install.sh"
+curl -fsSL https://raw.githubusercontent.com/jasonmorganson/dotfiles/main/install.sh |
+  sh
 ```
 
-You can optionally run `export GITHUB_USER="your-github-user"` first to use that
-GitHub profile and its SSH keys. The value is not stored in the mise config.
-Otherwise, bootstrap detects the authenticated GitHub CLI user when possible.
+Optionally use a different GitHub username and dotfiles repository:
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/jasonmorganson/dotfiles/main/install.sh |
+  GITHUB_USER="your-github-user" sh
+```
+
+The value is not stored in the mise config. Otherwise, bootstrap detects the
+authenticated GitHub CLI user when possible.
 
 ## Usage
 
@@ -27,8 +29,9 @@ Pull the latest dotfiles and reapply the machine configuration:
 bootstrap
 ```
 
-`install.sh` is the no-argument setup entrypoint used by Codespaces and similar
-environments. It installs `mise` to its standard user-local path before
+`install.sh` downloads the complete repository when streamed, or acts as the
+no-argument setup entrypoint used by Codespaces and similar environments when
+run from a checkout. It installs `mise` to its standard user-local path before
 bootstrapping:
 
 > `mise bootstrap --yes --force-dotfiles`

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,17 +7,19 @@ Dotfiles, bootstrapped with [`mise`](https://mise.jdx.dev/).
 Bootstrap a new machine with the following script:
 
 ```sh
-#!/bin/sh
-set -eu
-
-mkdir -p "$HOME/.local/share"
-git clone https://github.com/jasonmorganson/dotfiles.git "$HOME/.local/share/dotfiles"
-"$HOME/.local/share/dotfiles/install.sh"
+curl -fsSL https://raw.githubusercontent.com/jasonmorganson/dotfiles/main/install.sh |
+  sh
 ```
 
-You can optionally run `export GITHUB_USER="your-github-user"` first to use that
-GitHub profile and its SSH keys. The value is not stored in the mise config.
-Otherwise, bootstrap detects the authenticated GitHub CLI user when possible.
+Optionally use a different GitHub username and dotfiles repository:
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/jasonmorganson/dotfiles/main/install.sh |
+  GITHUB_USER="your-github-user" sh
+```
+
+The value is not stored in the mise config. Otherwise, bootstrap detects the
+authenticated GitHub CLI user when possible.
 
 ## Usage
 
@@ -27,8 +29,9 @@ Pull the latest dotfiles and reapply the machine configuration:
 bootstrap
 ```
 
-`install.sh` is the no-argument setup entrypoint used by Codespaces and similar
-environments. It installs `mise` to its standard user-local path before
+`install.sh` downloads the complete repository when streamed, or acts as the
+no-argument setup entrypoint used by Codespaces and similar environments when
+run from a checkout. It installs `mise` to its standard user-local path before
 bootstrapping:
 
 > `mise bootstrap --yes --force-dotfiles`

--- a/home/.config/mise/tasks/test/install
+++ b/home/.config/mise/tasks/test/install
@@ -7,6 +7,10 @@ installer="$repo_root/install.sh"
 
 grep -Fq 'cd "$(dirname "$0")"' "$installer" ||
     { echo "installer must resolve paths from its own directory" >&2; exit 1; }
+grep -Fq 'git clone "https://github.com/${GITHUB_USER:-jasonmorganson}/dotfiles.git"' "$installer" ||
+    { echo "streamed installer must support a GitHub user with a safe default" >&2; exit 1; }
+grep -Fq 'exec "$HOME/.local/share/dotfiles/install.sh"' "$installer" ||
+    { echo "streamed installer must continue from the checkout" >&2; exit 1; }
 grep -Fq 'curl -fsSL https://mise.run | sh' "$installer" ||
     { echo "installer must use the standard mise installer" >&2; exit 1; }
 grep -Fq '"$HOME/.local/bin/mise" bootstrap --yes --force-dotfiles' "$installer" ||

--- a/install.sh
+++ b/install.sh
@@ -2,6 +2,12 @@
 set -e
 
 cd "$(dirname "$0")"
+if [ ! -d home/.config/mise ]; then
+    mkdir -p "$HOME/.local/share"
+    git clone "https://github.com/${GITHUB_USER:-jasonmorganson}/dotfiles.git" "$HOME/.local/share/dotfiles"
+    exec "$HOME/.local/share/dotfiles/install.sh"
+fi
+
 curl -fsSL https://mise.run | sh
 MISE_CONFIG_DIR="$PWD/home/.config/mise" \
 MISE_DOTFILES_ROOT="$PWD/home" \


### PR DESCRIPTION
## Summary

- allow `install.sh` to clone the dotfiles repository when streamed
- support `GITHUB_USER` as the repository owner with a safe default
- document the simplest install and optional-username forms

## Validation

- `shellcheck install.sh`
- `mise run test`