### PR TITLE
Use custom dotfiles installer URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,14 +7,14 @@ Dotfiles, bootstrapped with [`mise`](https://mise.jdx.dev/).
 Bootstrap a new machine with the following script:
 
 ```sh
-curl -fsSL https://raw.githubusercontent.com/jasonmorganson/dotfiles/main/install.sh |
+curl -fsSL https://dotfiles.morganson.me |
   sh
 ```
 
 Optionally use a different GitHub username and dotfiles repository:
 
 ```sh
-curl -fsSL https://raw.githubusercontent.com/jasonmorganson/dotfiles/main/install.sh |
+curl -fsSL https://dotfiles.morganson.me |
   GITHUB_USER="your-github-user" sh
 ```
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,14 +7,14 @@ Dotfiles, bootstrapped with [`mise`](https://mise.jdx.dev/).
 Bootstrap a new machine with the following script:
 
 ```sh
-curl -fsSL https://raw.githubusercontent.com/jasonmorganson/dotfiles/main/install.sh |
+curl -fsSL https://dotfiles.morganson.me |
   sh
 ```
 
 Optionally use a different GitHub username and dotfiles repository:
 
 ```sh
-curl -fsSL https://raw.githubusercontent.com/jasonmorganson/dotfiles/main/install.sh |
+curl -fsSL https://dotfiles.morganson.me |
   GITHUB_USER="your-github-user" sh
 ```
 


### PR DESCRIPTION
## Summary

- use `https://dotfiles.morganson.me` in both setup examples
- retain the optional `GITHUB_USER` form

## Verification

- Cloudflare DNS record is proxied
- Single Redirect returns HTTP 302 to the raw GitHub installer
- `git diff --check`