### PR TITLE
Streamline the root README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,61 +1,17 @@
-# [dotfiles](https://jasonmorganson.github.io/dotfiles)
+# dotfiles
 
-Dotfiles, bootstrapped with [`mise`](https://mise.jdx.dev/).
+Dotfiles, bootstrapped and managed with [`mise`](https://mise.jdx.dev/).
 
-## Setup
-
-Bootstrap a new machine with the following script:
+## Install
 
 ```sh
-curl -fsSL https://dotfiles.morganson.me |
-  sh
+curl -fsSL https://dotfiles.morganson.me | sh
 ```
 
-Optionally use a different GitHub username and dotfiles repository:
-
-```sh
-curl -fsSL https://dotfiles.morganson.me |
-  GITHUB_USER="your-github-user" sh
-```
-
-The value is not stored in the mise config. Otherwise, bootstrap detects the
-authenticated GitHub CLI user when possible.
-
-## Usage
-
-Pull the latest dotfiles and reapply the machine configuration:
+## Update
 
 ```sh
 bootstrap
 ```
 
-`install.sh` downloads the complete repository when streamed, or acts as the
-no-argument setup entrypoint used by Codespaces and similar environments when
-run from a checkout. It installs `mise` to its standard user-local path before
-bootstrapping:
-
-> `mise bootstrap --yes --force-dotfiles`
-
-Bootstrap requires Git 2.54 or newer and installs mise-managed hk globally
-with config-based Git hooks. On macOS it installs a current Git through
-Homebrew when the active version is too old; repositories without `hk.pkl`
-remain unaffected.
-
-See [reference](https://mise.jdx.dev/).
-
-### macOS Touch ID for `sudo`
-
-The bootstrap requires mise `v2026.8.12` or newer to manage privileged system
-files. On macOS, it declaratively maintains `/etc/pam.d/sudo_local` with Touch
-ID enabled, using Apple’s update-persistent sudo override. Inspect the planned
-change before applying it:
-
-```sh
-mise bootstrap files status
-mise bootstrap files apply --dry-run
-bootstrap
-```
-
-### Docker Compose
-
-`docker-compose run dotfiles`
+[Read the full documentation](https://jasonmorganson.github.io/dotfiles/)

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,7 +15,7 @@ Optionally use a different GitHub username and dotfiles repository:
 
 ```sh
 curl -fsSL https://dotfiles.morganson.me |
-  GITHUB_USER="your-github-user" sh
+  GITHUB_USER="your_github_user" sh
 ```
 
 The value is not stored in the mise config. Otherwise, bootstrap detects the
@@ -55,3 +55,7 @@ mise bootstrap files status
 mise bootstrap files apply --dry-run
 bootstrap
 ```
+
+### Docker Compose
+
+`docker-compose run dotfiles`


### PR DESCRIPTION
## Summary

- reduce the root README to install, optional fork, update, and documentation links
- keep detailed bootstrap and platform guidance in `docs/README.md`
- move the Docker Compose note into the expanded documentation

## Validation

- `git diff --check`
- `mise run test:install`