### PR TITLE
Use dotfiles as the update command

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ curl -fsSL https://dotfiles.morganson.me | sh
 ## Update
 
 ```sh
-bootstrap
+dotfiles
 ```
 
 [Read the full documentation](https://jasonmorganson.github.io/dotfiles/)

--- a/docs/README.md
+++ b/docs/README.md
@@ -26,7 +26,7 @@ authenticated GitHub CLI user when possible.
 Pull the latest dotfiles and reapply the machine configuration:
 
 ```sh
-bootstrap
+dotfiles
 ```
 
 `install.sh` downloads the complete repository when streamed, or acts as the
@@ -53,7 +53,7 @@ change before applying it:
 ```sh
 mise bootstrap files status
 mise bootstrap files apply --dry-run
-bootstrap
+dotfiles
 ```
 
 ### Docker Compose

--- a/home/.config/mise/conf.d/50-aliases.toml
+++ b/home/.config/mise/conf.d/50-aliases.toml
@@ -1,8 +1,7 @@
 [shell_alias]
 
 # dotfiles
-dotfiles = "mise bootstrap dotfiles"
-bootstrap = "mise bootstrap repos apply --yes && mise bootstrap --yes --force-dotfiles"
+dotfiles = "mise bootstrap --update --yes --force-dotfiles"
 
 # Habits
 ag = "rg"

--- a/home/.config/mise/tasks/test/zsh-bootstrap
+++ b/home/.config/mise/tasks/test/zsh-bootstrap
@@ -46,8 +46,12 @@ grep -Fq 'min_version = "2026.8.12"' "$mise_config" ||
     { echo "mise config must require the bootstrap-capable mise release" >&2; exit 1; }
 grep -Fq 'auto_update = true' "$mise_config" ||
     { echo "mise must keep its standalone installation current" >&2; exit 1; }
-grep -Fq 'dotfiles = "mise bootstrap dotfiles"' "$aliases_config" ||
-    { echo "dotfiles alias must use the supported bootstrap command" >&2; exit 1; }
+grep -Fq 'dotfiles = "mise bootstrap --update --yes --force-dotfiles"' "$aliases_config" ||
+    { echo "dotfiles alias must update repositories and reapply the machine configuration" >&2; exit 1; }
+if grep -Eq '^bootstrap[[:space:]]*=' "$aliases_config"; then
+    echo "bootstrap compatibility alias must be removed" >&2
+    exit 1
+fi
 
 grep -Fq 'zsh = false' "$bootstrap_config" ||
     { echo "mise bootstrap must not also rewrite the dotfiles-owned ZDOTDIR entrypoint" >&2; exit 1; }


### PR DESCRIPTION
## Summary

- make `dotfiles` update repositories and reapply the full machine configuration
- remove the `bootstrap` compatibility alias
- update the root and expanded documentation
- enforce the replacement in the alias fixtures

## Validation

- `git diff --check`
- `mise run test`