### PR TITLE
ci: test bootstrap without GitHub user

### DIFF
--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -17,5 +17,3 @@ jobs:
     - uses: actions/checkout@v7
     - name: Run install script
       run: ./install.sh
-    - name: Re-run bootstrap without GitHub user
-      run: env -u GITHUB_USER "$HOME/.local/bin/mise" run bootstrap

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -19,3 +19,5 @@ jobs:
       run: ./install.sh
     - name: Re-run bootstrap without GitHub user
       run: env -u GITHUB_USER "$HOME/.local/bin/mise" run bootstrap
+    - name: Verify Touch ID sudo bootstrap declaration
+      run: ./scripts/test-touch-id-sudo-bootstrap.sh

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -19,5 +19,3 @@ jobs:
       run: ./install.sh
     - name: Re-run bootstrap without GitHub user
       run: env -u GITHUB_USER "$HOME/.local/bin/mise" run bootstrap
-    - name: Verify Touch ID sudo bootstrap declaration
-      run: ./scripts/test-touch-id-sudo-bootstrap.sh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,8 @@ on: pull_request
 
 env:
   MISE_CONFIG_DIR: ${{ github.workspace }}/home/.config/mise
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  GITHUB_USER: ${{ github.repository_owner }}
 
 jobs:
   test:

--- a/home/.config/mise/tasks/test/bootstrap-without-github-user
+++ b/home/.config/mise/tasks/test/bootstrap-without-github-user
@@ -1,0 +1,7 @@
+#!/bin/sh
+#MISE description="Verify bootstrap can re-run without a GitHub user."
+set -eu
+
+repo_root="$(CDPATH= cd -P -- "$MISE_TASK_DIR/../../../../.." && pwd)"
+"$repo_root/install.sh"
+env -u GITHUB_USER "$HOME/.local/bin/mise" run bootstrap


### PR DESCRIPTION
## Summary
- move the credential-free bootstrap rerun into a mise test task
- make the test install first, then rerun bootstrap without GITHUB_USER
- keep the pull-request workflow focused on mise run test

## Validation
- sh -n home/.config/mise/tasks/test/bootstrap-without-github-user
- mise tasks ls (confirmed test:bootstrap-without-github-user)