### PR TITLE
fix: use standard mise zsh activation

### DIFF
--- a/home/.config/mise/conf.d/20-bootstrap.toml
+++ b/home/.config/mise/conf.d/20-bootstrap.toml
@@ -4,10 +4,7 @@
 "~/.config/nushell/scripts/nu_scripts" = { url = "https://github.com/nushell/nu_scripts.git" }
 
 [bootstrap.mise_shell_activate]
-# ZDOTDIR points at ~/.config/zsh. Keep that entrypoint dotfiles-owned so tool
-# upgrades cannot leave a generated, version-pinned Pitchfork integration
-# behind; the entrypoint still evaluates mise's generated activation.
-zsh = false
+zsh = true
 bash = true
 fish = true
 

--- a/home/.config/mise/conf.d/30-dotfiles.toml
+++ b/home/.config/mise/conf.d/30-dotfiles.toml
@@ -16,6 +16,10 @@
 "~/.config/mise/tasks/test" = { mode = "symlink" }
 "~/.bash_profile/local" = { block = '[[ -f "$HOME/.bashrc" ]] && . "$HOME/.bashrc"' }
 "~/.bashrc/local" = { block = '[[ -f "$HOME/.config/bash/rc" ]] && . "$HOME/.config/bash/rc"' }
+"~/.zshrc/local" = { block = '''
+[[ -f "$HOME/.config/zsh/rc" ]] && . "$HOME/.config/zsh/rc"
+[[ -f "$HOME/.config/zsh/preferences.zsh" ]] && . "$HOME/.config/zsh/preferences.zsh"
+''' }
 "~/.config/fish/conf.d/preferences.fish" = { mode = "copy" }
 "~/.config/docker/config.json" = { mode = "copy" }
 "~/.config/git/absorb" = { mode = "copy" }
@@ -56,7 +60,6 @@
 "~/.config/ssh/mac" = { mode = "copy" }
 "~/.config/ssh/term" = { mode = "copy" }
 "~/.config/zsh/preferences.zsh" = { mode = "copy" }
-"~/.config/zsh/.zshrc" = { mode = "copy" }
 "~/.docker" = { source = "~/.config/docker", mode = "symlink" }
 "~/.hushlogin" = { mode = "copy" }
 "~/.ssh/config" = { mode = "copy" }

--- a/home/.config/mise/conf.d/50-aliases.toml
+++ b/home/.config/mise/conf.d/50-aliases.toml
@@ -29,6 +29,3 @@ pip = "python -m pip"
 k = "kubectl"
 kns = "kubens"
 kctx = "kubectx"
-
-# Node
-node = "node --experimental-transform-types"

--- a/home/.config/mise/tasks/test/zsh-bootstrap
+++ b/home/.config/mise/tasks/test/zsh-bootstrap
@@ -3,7 +3,6 @@
 set -eu
 
 repo_root="$(CDPATH= cd -P -- "$MISE_TASK_DIR/../../../../.." && pwd)"
-zshrc="$repo_root/home/.config/zsh/.zshrc"
 dotfiles="$repo_root/home/.config/mise/conf.d/30-dotfiles.toml"
 bootstrap="$repo_root/home/.config/mise/tasks/bootstrap"
 bootstrap_config="$repo_root/home/.config/mise/conf.d/20-bootstrap.toml"
@@ -11,22 +10,11 @@ environment_config="$repo_root/home/.config/mise/conf.d/40-env.toml"
 aliases_config="$repo_root/home/.config/mise/conf.d/50-aliases.toml"
 mise_config="$repo_root/home/.config/mise/config.toml"
 
-grep -Fq 'eval "$("$HOME/.local/bin/mise" activate zsh)"' "$zshrc" ||
-    { echo "zsh must activate through the standard user-local mise path" >&2; exit 1; }
+grep -Fq '"~/.zshrc/local"' "$dotfiles" ||
+    { echo "generated zsh integrations must be sourced from the standard zshrc" >&2; exit 1; }
 
-activation_line="$(grep -nF '$HOME/.local/bin/mise" activate zsh' "$zshrc" | cut -d: -f1)"
-integration_line="$(grep -nF '$HOME/.config/zsh/rc' "$zshrc" | cut -d: -f1)"
-[ "$activation_line" -lt "$integration_line" ] ||
-    { echo "mise must activate before generated tool integrations" >&2; exit 1; }
-
-[ "$(grep -Fc '$HOME/.config/zsh/rc' "$zshrc")" -eq 1 ] ||
-    { echo "generated zsh integrations must be sourced exactly once" >&2; exit 1; }
-
-grep -Fq '"~/.config/zsh/.zshrc" = { mode = "copy" }' "$dotfiles" ||
-    { echo "ZDOTDIR zshrc is not owned by the dotfiles manifest" >&2; exit 1; }
-
-if grep -Fq '"~/.zshrc/local"' "$dotfiles"; then
-    echo "inactive HOME zshrc integration must not be generated alongside ZDOTDIR" >&2
+if grep -Fq '"~/.config/zsh/.zshrc"' "$dotfiles"; then
+    echo "the legacy ZDOTDIR zshrc must not be managed" >&2
     exit 1
 fi
 
@@ -53,8 +41,13 @@ if grep -Eq '^bootstrap[[:space:]]*=' "$aliases_config"; then
     exit 1
 fi
 
-grep -Fq 'zsh = false' "$bootstrap_config" ||
-    { echo "mise bootstrap must not also rewrite the dotfiles-owned ZDOTDIR entrypoint" >&2; exit 1; }
+grep -Fq 'zsh = true' "$bootstrap_config" ||
+    { echo "mise bootstrap must own standard zsh activation" >&2; exit 1; }
+
+if grep -Fq 'node = "node --experimental-transform-types"' "$aliases_config"; then
+    echo "node must not be wrapped by a shell alias" >&2
+    exit 1
+fi
 
 grep -Fq '"{{ env.NPM_CONFIG_PREFIX }}/bin"' "$environment_config" ||
     { echo "mise PATH must include npm's configured global bin directory" >&2; exit 1; }

--- a/home/.config/zsh/.zshrc
+++ b/home/.config/zsh/.zshrc
@@ -1,6 +1,0 @@
-# Activate the standard user-local mise installation before generated tool
-# integrations are sourced.
-eval "$("$HOME/.local/bin/mise" activate zsh)"
-
-[[ -f "$HOME/.config/zsh/rc" ]] && . "$HOME/.config/zsh/rc"
-[[ -f "$HOME/.config/zsh/preferences.zsh" ]] && . "$HOME/.config/zsh/preferences.zsh"


### PR DESCRIPTION
## Summary

- let mise generate and own its standard zsh activation target
- move dotfiles-owned zsh customization into the standard `~/.zshrc/local` hook
- remove the obsolete Node shell alias and legacy ZDOTDIR-managed zsh entrypoint
- update the mise-owned zsh bootstrap test for the new ownership model

## Validation

- `MISE_CONFIG_DIR=<worktree>/home/.config/mise mise run test:zsh-bootstrap`
- `git diff --check origin/main...HEAD`

The focused test passes. The aggregate `mise run test` reaches the bootstrap rerun fixture but stops on the pre-existing, unrelated local `home/.config/mise/mise.lock` modification in the main dotfiles checkout; that file is not included in this PR.
