### PR TITLE
fix: make macOS PAM bootstrap self-contained

### DIFF
--- a/home/.config/mise/config.macos.toml
+++ b/home/.config/mise/config.macos.toml
@@ -1,5 +1,9 @@
 [bootstrap.files."/etc/pam.d/sudo_local"]
-source = "files/etc/pam.d/sudo_local"
+content = """
+# sudo_local: local config file which survives system update and is included for sudo
+# uncomment following line to enable Touch ID for sudo
+auth       sufficient     pam_tid.so
+"""
 owner = "root"
 group = "wheel"
 mode = "0444"

--- a/home/.config/mise/files/etc/pam.d/sudo_local
+++ b/home/.config/mise/files/etc/pam.d/sudo_local
@@ -1,3 +1,0 @@
-# sudo_local: local config file which survives system update and is included for sudo
-# uncomment following line to enable Touch ID for sudo
-auth       sufficient     pam_tid.so

--- a/home/.config/mise/tasks/test/touch-id-sudo
+++ b/home/.config/mise/tasks/test/touch-id-sudo
@@ -4,7 +4,6 @@ set -eu
 
 repo_root="$(CDPATH= cd -P -- "$MISE_TASK_DIR/../../../../.." && pwd)"
 platform_config="$repo_root/home/.config/mise/config.macos.toml"
-source_file="$repo_root/home/.config/mise/files/etc/pam.d/sudo_local"
 dotfiles="$repo_root/home/.config/mise/conf.d/30-dotfiles.toml"
 miserc="$repo_root/home/.config/mise/miserc.toml"
 
@@ -13,19 +12,16 @@ grep -Fxq 'auto_env = true' "$miserc" ||
 
 grep -Fq '[bootstrap.files."/etc/pam.d/sudo_local"]' "$platform_config" ||
     { echo "Touch ID sudo override must be managed by bootstrap.files" >&2; exit 1; }
-grep -Fxq 'source = "files/etc/pam.d/sudo_local"' "$platform_config" ||
-    { echo "Touch ID sudo override must use the checked-in source" >&2; exit 1; }
+grep -Fxq 'auth       sufficient     pam_tid.so' "$platform_config" ||
+    { echo "Touch ID sudo override must enable pam_tid" >&2; exit 1; }
 grep -Fxq 'owner = "root"' "$platform_config" ||
     { echo "Touch ID sudo override must be root-owned" >&2; exit 1; }
 grep -Fxq 'group = "wheel"' "$platform_config" ||
     { echo "Touch ID sudo override must use macOS wheel group" >&2; exit 1; }
 grep -Fxq 'mode = "0444"' "$platform_config" ||
     { echo "Touch ID sudo override must preserve Apple template permissions" >&2; exit 1; }
-grep -Fxq 'auth       sufficient     pam_tid.so' "$source_file" ||
-    { echo "Touch ID sudo override must enable pam_tid" >&2; exit 1; }
 grep -Fq '"~/.config/mise/config.macos.toml" = { mode = "symlink" }' "$dotfiles" ||
     { echo "macOS mise config must be dotfiles-managed" >&2; exit 1; }
 grep -Fq '"~/.config/mise/miserc.toml" = { mode = "symlink" }' "$dotfiles" ||
     { echo "mise early-init config must be dotfiles-managed" >&2; exit 1; }
-
 echo "Touch ID sudo bootstrap fixtures passed"


### PR DESCRIPTION
## Summary
- inline the macOS Touch ID sudo override in the platform-specific mise config
- remove the bootstrap-time source-path dependency and obsolete source fixture
- keep the declarative ownership and mode checks

## Validation
- `mise run test`
- `mise bootstrap files status`
- `mise bootstrap files apply --dry-run --yes`
- `mise exec -- hk fix` *(not configured)*
- `mise exec -- hk check` *(not configured)*