### PR TITLE
Fix Codex mise bootstrap bridge

### DIFF
--- a/home/.config/mise/config.macos.toml
+++ b/home/.config/mise/config.macos.toml
@@ -1,3 +1,14 @@
+[bootstrap.files."/usr/local/bin/mise"]
+content = """
+#!/bin/sh
+exec "{{ env.HOME }}/.local/bin/mise" "$@"
+"""
+template = true
+owner = "root"
+group = "wheel"
+mode = "0755"
+replace = true
+
 [bootstrap.files."/etc/pam.d/sudo_local"]
 content = """
 # sudo_local: local config file which survives system update and is included for sudo

--- a/home/.config/mise/tasks/bootstrap
+++ b/home/.config/mise/tasks/bootstrap
@@ -76,6 +76,24 @@ grep -q '^github.com ' ~/.ssh/known_hosts 2>/dev/null || ssh-keyscan github.com 
 grep -q '^\[ssh.github.com\]:443 ' ~/.ssh/known_hosts 2>/dev/null || ssh-keyscan -p 443 ssh.github.com >> ~/.ssh/known_hosts 2>/dev/null
 
 if [ "$(uname -s)" = Darwin ]; then
+    mise_binary="$HOME/.local/bin/mise"
+    codex_mise_bridge=/usr/local/bin/mise
+    if [ -x "$mise_binary" ]; then
+        if [ -L "$codex_mise_bridge" ]; then
+            [ "$(readlink "$codex_mise_bridge")" = "$mise_binary" ] || {
+                echo "$codex_mise_bridge must point to $mise_binary" >&2
+                exit 1
+            }
+        elif [ -e "$codex_mise_bridge" ]; then
+            echo "$codex_mise_bridge exists and is not a mise bridge" >&2
+            exit 1
+        elif [ -w /usr/local/bin ]; then
+            ln -s "$mise_binary" "$codex_mise_bridge"
+        else
+            echo "Cannot create $codex_mise_bridge; create it with elevated permissions." >&2
+        fi
+    fi
+
     mise_path=$(mise env --json | jaq -r '.PATH')
     [ -n "$mise_path" ] && [ "$mise_path" != "null" ] &&
         launchctl setenv PATH "$mise_path"

--- a/home/.config/mise/tasks/bootstrap
+++ b/home/.config/mise/tasks/bootstrap
@@ -76,24 +76,6 @@ grep -q '^github.com ' ~/.ssh/known_hosts 2>/dev/null || ssh-keyscan github.com 
 grep -q '^\[ssh.github.com\]:443 ' ~/.ssh/known_hosts 2>/dev/null || ssh-keyscan -p 443 ssh.github.com >> ~/.ssh/known_hosts 2>/dev/null
 
 if [ "$(uname -s)" = Darwin ]; then
-    mise_binary="$HOME/.local/bin/mise"
-    codex_mise_bridge=/usr/local/bin/mise
-    if [ -x "$mise_binary" ]; then
-        if [ -L "$codex_mise_bridge" ]; then
-            [ "$(readlink "$codex_mise_bridge")" = "$mise_binary" ] || {
-                echo "$codex_mise_bridge must point to $mise_binary" >&2
-                exit 1
-            }
-        elif [ -e "$codex_mise_bridge" ]; then
-            echo "$codex_mise_bridge exists and is not a mise bridge" >&2
-            exit 1
-        elif [ -w /usr/local/bin ]; then
-            ln -s "$mise_binary" "$codex_mise_bridge"
-        else
-            echo "Cannot create $codex_mise_bridge; create it with elevated permissions." >&2
-        fi
-    fi
-
     mise_path=$(mise env --json | jaq -r '.PATH')
     [ -n "$mise_path" ] && [ "$mise_path" != "null" ] &&
         launchctl setenv PATH "$mise_path"

--- a/home/.config/mise/tasks/bootstrap
+++ b/home/.config/mise/tasks/bootstrap
@@ -76,6 +76,10 @@ grep -q '^github.com ' ~/.ssh/known_hosts 2>/dev/null || ssh-keyscan github.com 
 grep -q '^\[ssh.github.com\]:443 ' ~/.ssh/known_hosts 2>/dev/null || ssh-keyscan -p 443 ssh.github.com >> ~/.ssh/known_hosts 2>/dev/null
 
 if [ "$(uname -s)" = Darwin ]; then
+    mise_path=$(mise env --json | jaq -r '.PATH')
+    [ -n "$mise_path" ] && [ "$mise_path" != "null" ] &&
+        launchctl setenv PATH "$mise_path"
+
     mise env --dotenv |
     while IFS='=' read -r name value; do
         [ -n "$name" ] && launchctl setenv "$name" "$value"

--- a/home/.config/mise/tasks/test/touch-id-sudo
+++ b/home/.config/mise/tasks/test/touch-id-sudo
@@ -12,6 +12,12 @@ grep -Fxq 'auto_env = true' "$miserc" ||
 
 grep -Fq '[bootstrap.files."/etc/pam.d/sudo_local"]' "$platform_config" ||
     { echo "Touch ID sudo override must be managed by bootstrap.files" >&2; exit 1; }
+grep -Fq '[bootstrap.files."/usr/local/bin/mise"]' "$platform_config" ||
+    { echo "Codex mise bridge must be managed by bootstrap.files" >&2; exit 1; }
+grep -Fq 'exec "{{ env.HOME }}/.local/bin/mise" "$@"' "$platform_config" ||
+    { echo "Codex mise bridge must forward to mise's standard user-local installation" >&2; exit 1; }
+grep -Fq 'replace = true' "$platform_config" ||
+    { echo "Codex mise bridge must replace the legacy symlink" >&2; exit 1; }
 grep -Fxq 'auth       sufficient     pam_tid.so' "$platform_config" ||
     { echo "Touch ID sudo override must enable pam_tid" >&2; exit 1; }
 grep -Fxq 'owner = "root"' "$platform_config" ||

--- a/home/.config/mise/tasks/test/zsh-bootstrap
+++ b/home/.config/mise/tasks/test/zsh-bootstrap
@@ -48,10 +48,6 @@ grep -Fq "mise env --json | jaq -r '.PATH'" "$bootstrap" ||
     { echo "macOS GUI PATH must be derived from mise's JSON environment" >&2; exit 1; }
 grep -Fq 'launchctl setenv PATH "$mise_path"' "$bootstrap" ||
     { echo "macOS GUI PATH must be published through launchctl" >&2; exit 1; }
-grep -Fq 'codex_mise_bridge=/usr/local/bin/mise' "$bootstrap" ||
-    { echo "macOS bootstrap must manage Codex's stable mise bridge" >&2; exit 1; }
-grep -Fq 'mise_binary="$HOME/.local/bin/mise"' "$bootstrap" ||
-    { echo "Codex's mise bridge must target mise's standard user-local installation" >&2; exit 1; }
 
 if grep -Fq 'node = "node --experimental-transform-types"' "$aliases_config"; then
     echo "node must not be wrapped by a shell alias" >&2

--- a/home/.config/mise/tasks/test/zsh-bootstrap
+++ b/home/.config/mise/tasks/test/zsh-bootstrap
@@ -48,6 +48,10 @@ grep -Fq "mise env --json | jaq -r '.PATH'" "$bootstrap" ||
     { echo "macOS GUI PATH must be derived from mise's JSON environment" >&2; exit 1; }
 grep -Fq 'launchctl setenv PATH "$mise_path"' "$bootstrap" ||
     { echo "macOS GUI PATH must be published through launchctl" >&2; exit 1; }
+grep -Fq 'codex_mise_bridge=/usr/local/bin/mise' "$bootstrap" ||
+    { echo "macOS bootstrap must manage Codex's stable mise bridge" >&2; exit 1; }
+grep -Fq 'mise_binary="$HOME/.local/bin/mise"' "$bootstrap" ||
+    { echo "Codex's mise bridge must target mise's standard user-local installation" >&2; exit 1; }
 
 if grep -Fq 'node = "node --experimental-transform-types"' "$aliases_config"; then
     echo "node must not be wrapped by a shell alias" >&2

--- a/home/.config/mise/tasks/test/zsh-bootstrap
+++ b/home/.config/mise/tasks/test/zsh-bootstrap
@@ -44,6 +44,11 @@ fi
 grep -Fq 'zsh = true' "$bootstrap_config" ||
     { echo "mise bootstrap must own standard zsh activation" >&2; exit 1; }
 
+grep -Fq "mise env --json | jaq -r '.PATH'" "$bootstrap" ||
+    { echo "macOS GUI PATH must be derived from mise's JSON environment" >&2; exit 1; }
+grep -Fq 'launchctl setenv PATH "$mise_path"' "$bootstrap" ||
+    { echo "macOS GUI PATH must be published through launchctl" >&2; exit 1; }
+
 if grep -Fq 'node = "node --experimental-transform-types"' "$aliases_config"; then
     echo "node must not be wrapped by a shell alias" >&2
     exit 1


### PR DESCRIPTION
## Summary
- publish mise-computed PATH to the macOS GUI environment
- declaratively manage `/usr/local/bin/mise` as a privileged, portable bootstrap wrapper for fixed-PATH hosts such as Codex
- cover the bootstrap configuration with focused regression checks

## Validation
- `mise run test:zsh-bootstrap`
- `mise run test:touch-id-sudo`
- `mise bootstrap files apply --dry-run`